### PR TITLE
Mark wiki edits as bot edit

### DIFF
--- a/plugins/mediawiki.py
+++ b/plugins/mediawiki.py
@@ -23,4 +23,4 @@ class MediaWiki(Plugin):
     date = now.strftime("%Y-%m-%d %H:%M")
     cat = category.Category(self.site, "Linklist")
     for article in cat.getAllMembersGen(namespaces=[0]):
-      print article.edit(appendtext="\n* {title} - {url} ({date}) \n".format(title=title, url=url, date=date))
+      print article.edit(appendtext="\n* {title} - {url} ({date}) \n".format(title=title, url=url, date=date), bot=True)


### PR DESCRIPTION
Unsere Rezeptionistin macht einen großartigen Job, aber auf der [Letzte Änderungen](https://k4cg.org/index.php/Spezial:Letzte_%C3%84nderungen)-Seite sind ihre Änderungen irgendwie nutzlos.

Das schöne ist, man kann auf der Letzten Änderungen Seite Bot-Edits herausfiltern, dazu muss der Edit aber entsprechend gekennzeichnet werden. Die [Mediawiki-API](https://www.mediawiki.org/wiki/API:Edit#Parameters) gibt das her und unsere [Wikitools-Lib](https://github.com/alexz-enwp/wikitools/wiki/page.Page#edit) scheint es auch zu unterstützen.